### PR TITLE
Only build for win-64

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,8 @@ source:
 
 build:
   number: 0
-  skip: true  # [not win]
+  # win-arm64 will support Windows 11 and later, so it gets ucrt from the system. 
+  skip: true  # [not win64]
 
 requirements:
   build:


### PR DESCRIPTION
win-arm64 will be for Windows 11+. UCRT comes with the OS since Windows 10. 

skip-existing doesn't seem to be working as expected. But this doesn't need to be released, the release will be dropped in PBP. 